### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,11 +135,11 @@ implementation, and the application policies should be fixed:
 ## 1.6.0 (2018-05-26)
 
 - Allow `permit_mass_assignment_of` and `forbid_mass_assignment_of` to accept
-  an array of attributes for testing the mass asignment of multiple attributes.
+  an array of attributes for testing the mass assignment of multiple attributes.
 
 ## 1.5.1 (2018-05-12)
 
-- Remove configuration from being in a seperate file (to get gem working again).
+- Remove configuration from being in a separate file (to get gem working again).
 
 ## 1.5.0 (2018-05-12)
 

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ unpublished articles, while administrators have full access to all articles.
 Visitors can only set the slug attribute when creating an article.
 
 To avoid deeply nested context trees it is a good idea to split larger policy
-specs up into multiple files. Here we divide the policy spec into seperate files
+specs up into multiple files. Here we divide the policy spec into separate files
 for the visitor and administrator contexts, but you could just as easily split
 the files by published status or policy action.
 

--- a/spec/pundit/matchers/permit_attributes_matcher_spec.rb
+++ b/spec/pundit/matchers/permit_attributes_matcher_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Pundit::Matchers::PermitAttributesMatcher do
       end.not_to raise_error
     end
 
-    context 'when matcher has been initializated with more than one attribute' do
+    context 'when matcher has been initialized with more than one attribute' do
       it 'raises an argument error' do
         expect do
           described_class.new(test: %i[nest1 nest2]).ensure_single_attribute!

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples_for 'an actions matcher' do
   end
 
   describe '#ensure_single_action!' do
-    context 'when matcher has been initializated with more than one action' do
+    context 'when matcher has been initialized with more than one action' do
       it 'raises an argument error' do
         expect do
           described_class.new(:test, :test2).ensure_single_action!


### PR DESCRIPTION
Automatic, via [codespell](https://github.com/codespell-project/codespell)