### PR TITLE
Update RuboCop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem 'bundler', '~> 2.4'
 gem 'rake', '~> 13.2'
-gem 'rubocop', '~> 1.65', require: false
+gem 'rubocop', '~> 1.66', require: false
 gem 'rubocop-packaging', '~> 0.5.2', require: false
 gem 'rubocop-performance', '~> 1.21', require: false
 gem 'rubocop-rake', '~> 0.6.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     docile (1.4.1)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    parallel (1.26.2)
+    parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
@@ -23,29 +23,26 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.6)
-      strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.65.1)
+    rubocop (1.66.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.4, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      rubocop-ast (>= 1.32.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.0)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     rubocop-packaging (0.5.2)
       rubocop (>= 1.33, < 2.0)
@@ -63,7 +60,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    strscan (3.1.0)
     unicode-display_width (2.5.0)
     yard (0.9.36)
 
@@ -74,7 +70,7 @@ DEPENDENCIES
   bundler (~> 2.4)
   pundit-matchers!
   rake (~> 13.2)
-  rubocop (~> 1.65)
+  rubocop (~> 1.66)
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.21)
   rubocop-rake (~> 0.6.0)
@@ -83,4 +79,4 @@ DEPENDENCIES
   yard (~> 0.9.36)
 
 BUNDLED WITH
-   2.5.16
+   2.5.18

--- a/lib/pundit/matchers/forbid_all_actions_matcher.rb
+++ b/lib/pundit/matchers/forbid_all_actions_matcher.rb
@@ -34,7 +34,7 @@ module Pundit
       #
       # @return [String] Failure message.
       def failure_message
-        message = +"expected '#{policy_info}' to forbid all actions,"
+        message = "expected '#{policy_info}' to forbid all actions,"
         message << " but permitted #{policy_info.permitted_actions}"
         message << user_message
       end

--- a/lib/pundit/matchers/forbid_only_actions_matcher.rb
+++ b/lib/pundit/matchers/forbid_only_actions_matcher.rb
@@ -38,7 +38,7 @@ module Pundit
       #
       # @return [String] A failure message when the expected actions and the forbidden actions do not match.
       def failure_message
-        message = +"expected '#{policy_info}' to forbid only #{expected_actions},"
+        message = "expected '#{policy_info}' to forbid only #{expected_actions},"
         message << " but forbade #{actual_actions}" unless actual_actions.empty?
         message << extra_message unless extra_actions.empty?
         message << user_message

--- a/lib/pundit/matchers/permit_actions_matcher.rb
+++ b/lib/pundit/matchers/permit_actions_matcher.rb
@@ -47,7 +47,7 @@ module Pundit
       #
       # @return [String] A failure message when the expected actions are not forbidden.
       def failure_message
-        message = +"expected '#{policy_info}' to permit #{expected_actions},"
+        message = "expected '#{policy_info}' to permit #{expected_actions},"
         message << " but forbade #{actual_actions}"
         message << user_message
       end
@@ -56,7 +56,7 @@ module Pundit
       #
       # @return [String] A failure message when the expected actions are permitted.
       def failure_message_when_negated
-        message = +"expected '#{policy_info}' to forbid #{expected_actions},"
+        message = "expected '#{policy_info}' to forbid #{expected_actions},"
         message << " but permitted #{actual_actions}"
         message << user_message
       end

--- a/lib/pundit/matchers/permit_all_actions_matcher.rb
+++ b/lib/pundit/matchers/permit_all_actions_matcher.rb
@@ -34,7 +34,7 @@ module Pundit
       #
       # @return [String] A failure message when the policy does not permit all actions.
       def failure_message
-        message = +"expected '#{policy_info}' to permit all actions,"
+        message = "expected '#{policy_info}' to permit all actions,"
         message << " but forbade #{policy_info.forbidden_actions}"
         message << user_message
       end

--- a/lib/pundit/matchers/permit_attributes_matcher.rb
+++ b/lib/pundit/matchers/permit_attributes_matcher.rb
@@ -41,7 +41,7 @@ module Pundit
       #
       # @return [String] A failure message when the expected attributes are not permitted.
       def failure_message
-        message = +"expected '#{policy_info}' to permit the mass assignment of #{expected_attributes}"
+        message = "expected '#{policy_info}' to permit the mass assignment of #{expected_attributes}"
         message << action_message if options.key?(:action)
         message << ", but forbade the mass assignment of #{actual_attributes}"
         message << user_message
@@ -51,7 +51,7 @@ module Pundit
       #
       # @return [String] A failure message when the expected attributes are forbidden.
       def failure_message_when_negated
-        message = +"expected '#{policy_info}' to forbid the mass assignment of #{expected_attributes}"
+        message = "expected '#{policy_info}' to forbid the mass assignment of #{expected_attributes}"
         message << action_message if options.key?(:action)
         message << ", but permitted the mass assignment of #{actual_attributes}"
         message << user_message

--- a/lib/pundit/matchers/permit_only_actions_matcher.rb
+++ b/lib/pundit/matchers/permit_only_actions_matcher.rb
@@ -38,7 +38,7 @@ module Pundit
       #
       # @return [String] A failure message when the expected actions and the permitted actions do not match.
       def failure_message
-        message = +"expected '#{policy_info}' to permit only #{expected_actions},"
+        message = "expected '#{policy_info}' to permit only #{expected_actions},"
         message << " but permitted #{actual_actions}" unless actual_actions.empty?
         message << extra_message unless extra_actions.empty?
         message << user_message


### PR DESCRIPTION
Autofix safe `Style/RedundantInterpolationUnfreeze` offenses: interpolated strings are already unfrozen.

```
Comparison:
         "test #{1}":  8929208.6 i/s
        +"test #{1}":  7853049.9 i/s - 1.14x  (± 0.00) slower
```