### PR TITLE
Assign `dependabot-reviewers` to Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - pundit-community/dependabot-reviewers
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -12,3 +14,5 @@ updates:
       rubocop:
         patterns:
           - "rubocop*"
+    reviewers:
+      - pundit-community/dependabot-reviewers


### PR DESCRIPTION
Close #219

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers--

---

No idea if this works