### PR TITLE
Update dependencies, actions, and RuboCop config

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -22,7 +22,7 @@ jobs:
         ruby-version: ["3.1"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     continue-on-error: ${{ matrix.channel != 'stable' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -22,7 +22,7 @@ jobs:
         ruby-version: ['3.4']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ AllCops:
 # Configured to allow the use of `does_not_match?`, as it aligns with the RSpec Matcher Protocol.
 # This method is part of RSpec's internal API for defining custom matchers.
 # Reference: https://www.rubydoc.info/github/rspec/rspec-expectations/RSpec/Matchers/MatcherProtocol#does_not_match%3F-instance_method
-Naming/PredicateName:
+Naming/PredicatePrefix:
   AllowedMethods:
     - does_not_match?
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    diff-lcs (1.6.0)
+    diff-lcs (1.6.2)
     docile (1.4.1)
     json (2.13.2)
     language_server-protocol (3.17.0.5)
@@ -24,17 +24,17 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
-    regexp_parser (2.11.1)
-    rspec-core (3.13.3)
+    regexp_parser (2.11.2)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.2)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.2)
-    rubocop (1.79.2)
+    rspec-support (3.13.5)
+    rubocop (1.80.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -66,9 +66,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.1)
+    simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    unicode-display_width (3.1.4)
+    unicode-display_width (3.1.5)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     yard (0.9.37)
@@ -89,4 +89,4 @@ DEPENDENCIES
   yard (~> 0.9.37)
 
 BUNDLED WITH
-   2.6.6
+   2.7.1


### PR DESCRIPTION
Fix a RuboCop warning related to a renamed cop:
```
Warning: Using `Naming/PredicateName` configuration in .rubocop.yml for `Naming/PredicatePrefix`.
```